### PR TITLE
Don't reply as sender in multi-recipient emails

### DIFF
--- a/background.js
+++ b/background.js
@@ -40,7 +40,19 @@ const on_compose_start = async (tab, win)=>{
 			let identityName = splitAddr(msg.from);
 			if (!originalTo) {
 				if (oriMsg.headers['to'].length==1) {
-					originalTo = oriMsg.headers['to'][0];
+					let split_recipients = oriMsg.headers['to'][0].split(", ");
+					if (split_recipients.length > 1) {
+						let addr;
+						for (addr in split_recipients) {
+							if (splitAddr(split_recipients[addr])[1] !=
+							    splitAddr(oriMsg.headers['from'][0])[1]) {
+								originalTo = split_recipients[addr];
+								break;
+							}
+						}
+					}
+					if (!originalTo)
+						originalTo = oriMsg.headers['to'][0];
 				}
 			}
 			


### PR DESCRIPTION
I've got a particularly pedantic contact that insists on including himself as the first recipient in every email he sends. Apparently, they have no concept of the "Sent" folder. I've asked them multiple times to please refrain from that behavior when sending me an email, but that's just what they do.

Due to their insistence on this, when using this extension to reply, it attempts to reply with their address -- which obviously won't work. So, I extended the functionality in order to use the first address that isn't the original From address. It's not a perfect solution, but it works for my use case and doesn't interfere with the original behavior.

Room for improvement:
I haven't looked to see if it's possible to enumerate the identities, but if that's possible, it would be pretty trivial to pick the correct reply address by enumerating the original To addresses and matching one to the domain of an identity. Of course, it wouldn't be so helpful with a domain like Gmail, but it's an edge case as it stands...

PS: I also created a whitespace-fixed version of this as well.